### PR TITLE
Fix getVideoResolution overload definition

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,7 +131,7 @@ const info = await getVideoResolution(buffer);
 ```typescript
 function getVideoResolution(
   source: string | Buffer | Blob | ReadableStream,
-  options?: GetVideoResolutionOptions & { pick: "all" },
+  options: GetVideoResolutionOptions & { pick: "all" },
 ): Promise<VideoInfo[]>;
 
 function getVideoResolution(

--- a/src/resolver.ts
+++ b/src/resolver.ts
@@ -17,7 +17,7 @@ import { UnsupportedSourceError } from "./errors";
  */
 export async function getVideoResolution(
   source: string | Buffer | Blob | ReadableStream,
-  options?: GetVideoResolutionOptions & { pick: "all" },
+  options: GetVideoResolutionOptions & { pick: "all" },
 ): Promise<VideoInfo[]>;
 export async function getVideoResolution(
   source: string | Buffer | Blob | ReadableStream,


### PR DESCRIPTION
Hi! Incredible library! Finally an alternative to ffprobe, thank you so much!

### The issue:

Is it just me or does getVideoResolution presume "pick: all" when supplied with no options?

<img width="1033" height="255" alt="image" src="https://github.com/user-attachments/assets/7eaaf6ed-5054-4f0b-8d49-d10119a5cc74" />

It's strange because the code runs correctly, but typescript linting reports it as an error.

The overloads are a bit too complicated for me, but AI assistants consistently tell me that the overload order is incorrect, and this should be the fix. From Claude 4.6:

> Yes, there's a bug. The first overload marks `options` as optional (`?`), so calling `getVideoResolution("url")` without options matches it and TypeScript infers the return type as `Promise<VideoInfo[]>` instead of `Promise<VideoInfo>`.
> 
> The fix is to make `options` required in the `pick: "all"` overload: 

And it does fix my issue, and works in the limited testing I performed.

I'd love to hear what you think!

Jan